### PR TITLE
Added ability for user to keep their settings file in their home directory

### DIFF
--- a/cfg/user-sample.lua
+++ b/cfg/user-sample.lua
@@ -4,7 +4,8 @@ Configuration files are loaded in the following order
 
 1. <application>\config.lua
 2. cfg\user.lua
-3. -cfg commandline strings
+3. ~\.zbs\user.lua
+4. -cfg commandline strings
 
 -- an example of how loaded configuration can be modified from this file
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -264,6 +264,7 @@ if app.preinit then app.preinit() end
 
 do
   addConfig("cfg/user.lua",false)
+  addConfig(os.getenv( "HOME" ) .. "/.zbs/user.lua",false)
   for i,v in ipairs(configs) do
     addConfig(v,true,true)
   end


### PR DESCRIPTION
More specifically, they can now keep their settings file in ~/.zbs/user.lua.

This is a more friendly location to keep settings file than next to the executable in c:\Program Files on windows or /Application on the mac.  This also allows settings to be different on a per-user basis.
