### PR TITLE
End-of-line related changes

### DIFF
--- a/src/defs.lua
+++ b/src/defs.lua
@@ -101,6 +101,8 @@ config = {
     autoactivate = false, -- auto-activate/open files during debugging
     smartindent = false, -- use smart indentation if spec allows
     foldcompact = true, -- use compact fold that includes empty lines
+    defaulteol = nil, -- default line-endings for new files; valid values are
+                      -- wxstc.wxSTC_EOL_CRLF, wxstc.wxSTC_EOL_LF and nil (OS default)
   },
 
   default = {

--- a/src/editor/commands.lua
+++ b/src/editor/commands.lua
@@ -96,6 +96,22 @@ function LoadFile(filePath, editor, file_must_exist, skipselection)
     local found = string.find(file_text,"\t") ~= nil
     editor:SetUseTabs(found)
   end
+  
+  -- Auto-detect CRLF/LF line-endings
+  local foundcrlf = string.find(file_text,"\r\n") ~= nil
+  local foundlf = (string.find(file_text,"[^\r]\n") ~= nil)
+    or (string.find(file_text,"^\n") ~= nil) -- edge case: file beginning with LF and having no other LF
+  if foundcrlf and foundlf then -- file with mixed line-endings
+    DisplayOutputLn(("%s: %s")
+      :format(filePath, TR("Mixed end-of-line encodings detected.")..' '..
+        TR("Use '%s' to show line endings and '%s' to convert them.")
+      :format("GetEditor():SetViewEOL(1)", "GetEditor():ConvertEOLs(GetEditor():GetEOLMode())")))
+  elseif foundcrlf then
+    editor:SetEOLMode(wxstc.wxSTC_EOL_CRLF)
+  elseif foundlf then
+    editor:SetEOLMode(wxstc.wxSTC_EOL_LF)
+  -- else (e.g. file is 1 line long or uses another line-ending): use default EOL mode
+  end
 
   editor:EmptyUndoBuffer()
   local id = editor:GetId()

--- a/src/editor/editor.lua
+++ b/src/editor/editor.lua
@@ -340,6 +340,12 @@ function CreateEditor()
     editor:SetWrapVisualFlagsLocation(wxstc.wxSTC_WRAPVISUALFLAGLOC_END_BY_TEXT)
   end
 
+  if (ide.config.editor.defaulteol == wxstc.wxSTC_EOL_CRLF
+     or ide.config.editor.defaulteol == wxstc.wxSTC_EOL_LF) then
+    editor:SetEOLMode(ide.config.editor.defaulteol)
+  -- else: keep wxStyledTextCtrl default behavior (CRLF on Windows, LF on Unix)
+  end
+
   editor:SetCaretLineVisible(ide.config.editor.caretline and 1 or 0)
 
   editor:SetVisiblePolicy(wxstc.wxSTC_VISIBLE_SLOP, 3)
@@ -447,7 +453,7 @@ function CreateEditor()
       local localpos = pos-linestart
       local linetxtopos = linetx:sub(1,localpos)
 
-      if (ch == char_CR and eol==2) or (ch == char_LF and eol==0) then
+      if (ch == char_LF) then
         if (line > 0) then
           local indent = editor:GetLineIndentation(line - 1)
           local linedone = editor:GetLine(line - 1)


### PR DESCRIPTION
Hi Paul,

I happen to switch regularly from a Windows box to a Linux one, and I've made some changes to the handling of line endings for my own convenience (and hopefully others' too):
-   I fixed a small bug preventing auto-indent to work on Unix systems (CR was tested instead of LF)
-   I added two new configuration settings:
  -   `useunixeol`
  -   `autoeol`

As you can guess by the names, they work quite similarly to `usetabs` / `autotabs`, but for line endings. By default `useunixeol` is not set, so the current behavior (wxStyledTextCtrl / Scintilla default) is kept: LF on Linux / MAC OS X, and CRLF on Windows.

One change may be controversial: since these two settings allow the user to meddle with line endings, I chose on file load to convert them all to whatever is the current EOL mode, to assure that no file can be ever saved with mixed line-endings. IMO, it is less serious to have a file converted unexpectedly than to silently save a file with both line endings; and it should make more sense to the end-user (and be more consistent) that ZBS always saves a file in one format or the other.

Regards,
Alexis
