### PR TITLE
 Bugfix for attempt to perform arithmetic on field 'wxMOD_RAW_CONTROL' (a nil value).

### DIFF
--- a/src/editor/editor.lua
+++ b/src/editor/editor.lua
@@ -660,8 +660,8 @@ function CreateEditor()
         if event:ShiftDown() -- mark selection and scroll to caret
         then editor:SetCurrentPos(pos) editor:EnsureCaretVisible()
         else editor:GotoPos(pos) end
-      elseif mod == wx.wxMOD_RAW_CONTROL and keycode == wx.WXK_PAGEUP
-        or mod == (wx.wxMOD_RAW_CONTROL + wx.wxMOD_SHIFT) and keycode == wx.WXK_TAB then
+      elseif mod == wx.wxMOD_RAW_CONTROL and (keycode == wx.WXK_PAGEUP
+        or mod == (wx.wxMOD_RAW_CONTROL + wx.wxMOD_SHIFT) and keycode == wx.WXK_TAB) then
         if notebook:GetSelection() == first
         then notebook:SetSelection(last)
         else notebook:AdvanceSelection(false) end


### PR DESCRIPTION
Fix for:
    Lua: Error while running chunk
    src/editor/editor.lua:664: attempt to perform arithmetic on field 'wxMOD_RAW_CONTROL' (a nil value)
    stack traceback:
        src/editor/editor.lua:664: in function <src/editor/editor.lua:649>
        [C]: in function 'MainLoop'
        src/main.lua:442: in main chunk
        [C]: ?

which happens with 0.361 using **Linux using wxwidgets 2.8**. This behaviour could also be present using Windows though unverified.
