### PR TITLE
Make code folding optional

### DIFF
--- a/src/defs.lua
+++ b/src/defs.lua
@@ -100,6 +100,7 @@ config = {
     calltipdelay = nil, -- delay to show calltip (in ms)
     autoactivate = false, -- auto-activate/open files during debugging
     smartindent = false, -- use smart indentation if spec allows
+    fold = true, -- enable code folding
     foldcompact = true, -- use compact fold that includes empty lines
     checkeol = true, -- check for eol encoding on loaded files and use it
                      -- also report mixed eol encodings

--- a/src/editor/editor.lua
+++ b/src/editor/editor.lua
@@ -615,10 +615,12 @@ function CreateEditor()
   editor:MarkerDefine(StylesGetMarker("currentline"))
   editor:MarkerDefine(StylesGetMarker("breakpoint"))
 
-  editor:SetMarginWidth(2, 16) -- fold margin
-  editor:SetMarginType(2, wxstc.wxSTC_MARGIN_SYMBOL)
-  editor:SetMarginMask(2, wxstc.wxSTC_MASK_FOLDERS)
-  editor:SetMarginSensitive(2, true)
+  if ide.config.editor.fold then
+    editor:SetMarginWidth(2, 16) -- fold margin
+    editor:SetMarginType(2, wxstc.wxSTC_MARGIN_SYMBOL)
+    editor:SetMarginMask(2, wxstc.wxSTC_MASK_FOLDERS)
+    editor:SetMarginSensitive(2, true)
+  end
 
   editor:SetFoldFlags(wxstc.wxSTC_FOLDFLAG_LINEBEFORE_CONTRACTED +
     wxstc.wxSTC_FOLDFLAG_LINEAFTER_CONTRACTED)
@@ -1187,9 +1189,11 @@ function SetupKeywords(editor, ext, forcespec, styles, font, fontitalic)
 
   -- need to set folding property after lexer is set, otherwise
   -- the folds are not shown (wxwidgets 2.9.5)
-  editor:SetProperty("fold", "1")
-  editor:SetProperty("fold.compact", ide.config.editor.foldcompact and "1" or "0")
-  editor:SetProperty("fold.comment", "1")
+  if ide.config.editor.fold then
+    editor:SetProperty("fold", "1")
+    editor:SetProperty("fold.compact", ide.config.editor.foldcompact and "1" or "0")
+    editor:SetProperty("fold.comment", "1")
+  end
   
   -- quickfix to prevent weird looks, otherwise need to update styling mechanism for cpp
   -- cpp "greyed out" styles are  styleid + 64

--- a/src/editor/menu_edit.lua
+++ b/src/editor/menu_edit.lua
@@ -23,10 +23,13 @@ local editMenu = wx.wxMenu{
   { },
   { ID_COMMENT, TR("C&omment/Uncomment")..KSC(ID_COMMENT), TR("Comment or uncomment current or selected lines") },
   { },
-  { ID_FOLD, TR("&Fold/Unfold All")..KSC(ID_FOLD), TR("Fold or unfold all code folds") },
   { ID_CLEARDYNAMICWORDS, TR("Clear &Dynamic Words")..KSC(ID_CLEARDYNAMICWORDS), TR("Resets the dynamic word list for autocompletion") },
   { },
 }
+
+if ide.config.editor.fold then
+  editMenu:Insert(14, ID_FOLD, TR("&Fold/Unfold All")..KSC(ID_FOLD), TR("Fold or unfold all code folds"))
+end
 
 local preferencesMenu = wx.wxMenu{
   {ID_PREFERENCESSYSTEM, TR("Settings: System")..KSC(ID_PREFERENCESSYSTEM)},

--- a/zbstudio/config.lua
+++ b/zbstudio/config.lua
@@ -6,6 +6,7 @@ editor.tabwidth = 2
 editor.usewrap = true
 editor.calltipdelay = 500
 editor.smartindent = true
+editor.fold = true
 
 local G = ... -- this now points to the global environment
 if G.ide.osname == 'Macintosh' then


### PR DESCRIPTION
Some users might consider code folding a needless distraction.
Several editors offer the option to turn code folding off.

This commit adds the editor.fold option, which is a boolean.
true enables code folding (default)
false disables code folding
