### PR TITLE
New styles: fold margin checker color and edge line

### DIFF
--- a/src/editor/style.lua
+++ b/src/editor/style.lua
@@ -198,6 +198,14 @@ local specialmapping = {
     end
   end,
 
+  edge = function(editor,style)
+    editor:SetEdgeMode(style.mode or wxstc.wxSTC_EDGE_LINE)
+    editor:SetEdgeColumn(style.col or 80)
+    if style.fg then
+      editor:SetEdgeColour(wx.wxColour(unpack(style.fg)))
+    end
+  end,
+
   marker = function(editor,markers)
     for m, style in pairs(markers) do
       local id, ch, fg, bg = StylesGetMarker(m)


### PR DESCRIPTION
styles.fold.hi
The color to use as the alternate background for the fold margin, allowing a checker effect when combined with styles.fold.bg

styles.edge
A style for inserting an edge line or background.

e.g., this creates a white line at 80 columns:

```
styles.edge = {
  mode = wxstc.wxSTC_EDGE_LINE,
  col = 80,
  fg = { 255, 255, 255 }
}
```
