### PR TITLE
Adding project dir to find dialog path when switching projects

### DIFF
--- a/src/editor/filetree.lua
+++ b/src/editor/filetree.lua
@@ -558,6 +558,9 @@ function filetree:updateProjectDir(newdir)
   -- refresh Recent Projects menu item
   ide.frame:AddPendingEvent(wx.wxUpdateUIEvent(ID_RECENTPROJECTS))
 
+  -- Add project dir to find replace window
+  PrependStringToArray(ide.findReplace.filedirTextArray, ide.config.path.projectdir) 
+	
   PackageEventHandle("onProjectLoad", newdir)
 end
 


### PR DESCRIPTION
If you do a find in files in one project, switch projects, and then bring up the dialog again it will only have the first project's path for searching. 

This change just adds the current project path to the search directory history. 

I opted to just add instead of replace to keep it flexible. You can still search the first project if doing so makes sense with your workflow, but this way you won't need to copy the path from somewhere or restart ZBS to get the new project's path in the search window.
