### PR TITLE
Added refresh context menu item to update the contents of the project tree

### DIFF
--- a/cfg/i18n/cn.lua
+++ b/cfg/i18n/cn.lua
@@ -207,6 +207,7 @@ return {
   ["Recent &Projects"] = nil, -- src\editor\menu_file.lua
   ["Recent Files"] = "最近的文档", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "重做最后被取消的编辑", -- src\editor\menu_edit.lua
+  ["Refresh"] = "刷新", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "因为有另一个除错在进行，拒绝开启新的除错对话", -- src\editor\debugger.lua
   ["Regular &expression"] = "正则表达式", -- src\editor\findreplace.lua
   ["Remote console"] = "远程主控台", -- src\editor\shellbox.lua

--- a/cfg/i18n/de.lua
+++ b/cfg/i18n/de.lua
@@ -208,6 +208,7 @@ return {
   ["Recent &Projects"] = "Letzte &Projekte", -- src\editor\menu_file.lua
   ["Recent Files"] = "Letzte Dateien", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Stelle letzte rückgängig gemachte Bearbeitung wieder her", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Erfrischen", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Starten einer neuen Debuggingsession abgelehnt, da bereits eine läuft.", -- src\editor\debugger.lua
   ["Regular &expression"] = "&Regulärer Ausdruck", -- src\editor\findreplace.lua
   ["Remote console"] = "Fensteuerungs-Konsole", -- src\editor\shellbox.lua

--- a/cfg/i18n/eo.lua
+++ b/cfg/i18n/eo.lua
@@ -209,6 +209,7 @@ return {
   ["Recent &Projects"] = "Antaŭnelongaj &projektoj", -- src\editor\menu_file.lua
   ["Recent Files"] = "Antaŭnelongaj dosieroj", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Refari lastan redakton", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Refreŝigu", -- src\editor\menu_file.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Peto por komenci novan sencimigan seancon malakceptis, ĉar seanco jam faratas.", -- src\editor\debugger.lua
   ["Regular &expression"] = "Regul&esprimo", -- src\editor\findreplace.lua
   ["Remote console"] = "Fora konzolo", -- src\editor\shellbox.lua

--- a/cfg/i18n/es.lua
+++ b/cfg/i18n/es.lua
@@ -209,6 +209,7 @@ return {
   ["Recent &Projects"] = nil, -- src\editor\menu_file.lua
   ["Recent Files"] = "Archivos recientes", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Rehacer la última edición deshecha", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Refrescar", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "No se pudo lanzar una nueva sesión de depuración porque ya hay una en curso.", -- src\editor\debugger.lua
   ["Regular &expression"] = nil, -- src\editor\findreplace.lua
   ["Remote console"] = "Consola remota", -- src\editor\shellbox.lua

--- a/cfg/i18n/fr.lua
+++ b/cfg/i18n/fr.lua
@@ -208,6 +208,7 @@ return {
   ["Recent &Projects"] = "&Projets récents", -- src\editor\menu_file.lua
   ["Recent Files"] = "Fichiers récents", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Rétablit la dernière modification", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Rafraîchir", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Une requête de lancement de débogage a été refusée car une session de débogage est déjà en cours.", -- src\editor\debugger.lua
   ["Regular &expression"] = "&Expression régulière", -- src\editor\findreplace.lua
   ["Remote console"] = "Console à distance", -- src\editor\shellbox.lua

--- a/cfg/i18n/it.lua
+++ b/cfg/i18n/it.lua
@@ -208,6 +208,7 @@ return {
   ["Recent &Projects"] = "Progetti Recenti", -- src\editor\menu_file.lua
   ["Recent Files"] = "Files recenti", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Ripeti l'ultima azione annullata", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Rinfrescare", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Impossibile aprire una nuova sessione di debug in quanto ne esiste una in corso", -- src\editor\debugger.lua
   ["Regular &expression"] = "Regular &expression", -- src\editor\findreplace.lua
   ["Remote console"] = "Console remota", -- src\editor\shellbox.lua

--- a/cfg/i18n/pt-br.lua
+++ b/cfg/i18n/pt-br.lua
@@ -211,6 +211,7 @@ return {
   ["Recent &Projects"] = "&Projetos recentes", -- src\editor\menu_file.lua
   ["Recent Files"] = "Arquivos recentes", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Refazer última edição desfeita", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Refrescar", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Solicitação de início de uma nova sessão de depuração recusado porque já existe um em progresso.", -- src\editor\debugger.lua
   ["Regular &expression"] = "&Expressão regular", -- src\editor\findreplace.lua
   ["Remote console"] = "Console remoto", -- src\editor\shellbox.lua

--- a/cfg/i18n/ru.lua
+++ b/cfg/i18n/ru.lua
@@ -209,6 +209,7 @@ return {
   ["Recent &Projects"] = "Недавние &проекты", -- src\editor\menu_file.lua
   ["Recent Files"] = "Недавние файлы", -- src\editor\menu_file.lua
   ["Redo last edit undone"] = "Вернуть последнее отмененное изменение", -- src\editor\menu_edit.lua
+  ["Refresh"] = "Oбновление", -- src\editor\filetree.lua
   ["Refused a request to start a new debugging session as there is one in progress already."] = "Отказано в запросе на запуск новой отладочной сессии, поскольку одна сессия уже выполняется.", -- src\editor\debugger.lua
   ["Regular &expression"] = "Регулярное выражение", -- src\editor\findreplace.lua
   ["Remote console"] = "Удаленная консоль", -- src\editor\shellbox.lua

--- a/src/editor/filetree.lua
+++ b/src/editor/filetree.lua
@@ -470,6 +470,8 @@ local function treeSetConnectorsAndIcons(tree)
         end
       end
     end)
+  tree:Connect(ID_REFRESH, wx.wxEVT_COMMAND_MENU_SELECTED,
+    function() refreshChildren() end)
   tree:Connect(ID_SHOWLOCATION, wx.wxEVT_COMMAND_MENU_SELECTED,
     function() ShowLocation(tree:GetItemFullName(tree:GetSelection())) end)
   tree:Connect(ID_HIDEEXTENSION, wx.wxEVT_COMMAND_MENU_SELECTED,
@@ -535,6 +537,7 @@ local function treeSetConnectorsAndIcons(tree)
         { ID_OPENEXTENSION, TR("Open With Default Program") },
         { ID_COPYFULLPATH, TR("Copy Full Path") },
         { ID_SHOWLOCATION, TR("Show Location") },
+        { ID_REFRESH, TR("Refresh") },
       }
       local extlist = {
         {},

--- a/src/editor/ids.lua
+++ b/src/editor/ids.lua
@@ -35,6 +35,7 @@ ID_UNMAPDIRECTORY   = NewID()
 ID_OPENEXTENSION    = NewID()
 ID_COPYFULLPATH     = NewID()
 ID_SHOWLOCATION     = NewID()
+ID_REFRESH          = NewID()
 ID_SAVE             = linux and NewID() or wx.wxID_SAVE
 ID_SAVEAS           = linux and NewID() or wx.wxID_SAVEAS
 ID_SAVEALL          = NewID()


### PR DESCRIPTION
Some projects generate/delete a lot of files and I wanted a way to refresh the project view in ZBS easier. I added a Refresh context menu item to re-display the project tree.
