### PR TITLE
Update love2d interpreter to use LÖVE in the name and description field

### DIFF
--- a/interpreters/love2d.lua
+++ b/interpreters/love2d.lua
@@ -5,8 +5,8 @@ local win = ide.osname == "Windows"
 local mac = ide.osname == "Macintosh"
 
 return {
-  name = "Love2d",
-  description = "Love2d game engine",
+  name = "LÖVE",
+  description = "LÖVE game engine",
   api = {"baselib", "love2d"},
   frun = function(self,wfilename,rundebug)
     love2d = love2d or ide.config.path.love2d -- check if the path is configured


### PR DESCRIPTION
I hope this doesn't come across as nitpicking, but the framework is called LÖVE and not love2d. 