### PR TITLE
new cosmetic OS X config options

### DIFF
--- a/src/editor/filetree.lua
+++ b/src/editor/filetree.lua
@@ -126,6 +126,9 @@ local function treeSetRoot(tree,rootdir)
   local root_id = tree:AddRoot(rootdir, image.DIRECTORY)
   tree:SetItemHasChildren(root_id, true) -- make sure that the item can expand
   tree:Expand(root_id) -- this will also populate the tree
+  if ide.config.theme.osxselection then
+    tree:UnselectAll()
+  end
 end
 
 local function findItem(tree, match)
@@ -624,6 +627,9 @@ local function treeSetConnectorsAndIcons(tree)
           if wx.wxFileExists(name) then LoadFile(name,nil,true) end
         end
       else
+        if ide.config.theme.osxselection then
+          tree:UnselectAll()
+        end
         event:Skip()
       end
       return true
@@ -695,7 +701,7 @@ projtree:SetFont(ide.font.fNormal)
 filetree.projtreeCtrl = projtree
 
 ide:GetProjectNotebook():AddPage(projtree, TR("Project"), true)
-
+ide:ThemePanel(projtree, "projtree")
 -- proj connectors
 -- ---------------
 

--- a/src/editor/gui.lua
+++ b/src/editor/gui.lua
@@ -142,6 +142,7 @@ local function createNotebook(frame)
     wx.wxDefaultPosition, wx.wxDefaultSize,
     wxaui.wxAUI_NB_DEFAULT_STYLE + wxaui.wxAUI_NB_TAB_EXTERNAL_MOVE
     + wxaui.wxAUI_NB_WINDOWLIST_BUTTON + wx.wxNO_BORDER)
+  ide:ThemeNotebook(notebook)
 
   -- wxEVT_SET_FOCUS could be used, but it only works on Windows with wx2.9.5+
   notebook:Connect(wxaui.wxEVT_COMMAND_AUINOTEBOOK_PAGE_CHANGED,
@@ -389,6 +390,7 @@ local function createBottomNotebook(frame)
     wx.wxDefaultPosition, wx.wxDefaultSize,
     wxaui.wxAUI_NB_DEFAULT_STYLE + wxaui.wxAUI_NB_TAB_EXTERNAL_MOVE
     - wxaui.wxAUI_NB_CLOSE_ON_ACTIVE_TAB + wx.wxNO_BORDER)
+  ide:ThemeNotebook(bottomnotebook)
 
   addDND(bottomnotebook)
 
@@ -425,6 +427,9 @@ local function createBottomNotebook(frame)
   bottomnotebook:AddPage(errorlog, TR("Output"), true)
   bottomnotebook:AddPage(shellbox, TR("Local console"), false)
 
+  ide:ThemePanel(errorlog, "errorlog")
+  ide:ThemePanel(shellbox, "shellbox")
+  
   bottomnotebook.errorlog = errorlog
   bottomnotebook.shellbox = shellbox
 
@@ -437,7 +442,8 @@ local function createProjNotebook(frame)
     wx.wxDefaultPosition, wx.wxDefaultSize,
     wxaui.wxAUI_NB_DEFAULT_STYLE + wxaui.wxAUI_NB_TAB_EXTERNAL_MOVE
     - wxaui.wxAUI_NB_CLOSE_ON_ACTIVE_TAB + wx.wxNO_BORDER)
-
+  ide:ThemeNotebook(projnotebook)
+  
   addDND(projnotebook)
 
   -- disallow tabs closing

--- a/src/editor/outline.lua
+++ b/src/editor/outline.lua
@@ -213,6 +213,9 @@ local function outlineCreateOutlineWindow()
     if item_id and item_id:IsOk() and bit.band(flags, mask) > 0 then
       ctrl:ActivateItem(item_id)
     else
+      if ide.config.theme.osxselection then
+        ctrl:UnselectAll()
+      end
       event:Skip()
     end
     return true

--- a/src/main.lua
+++ b/src/main.lua
@@ -132,6 +132,14 @@ ide = {
       menurecentprojects = "%f | %i",
       apptitle = "%T - %F",
     },
+    
+    theme = {
+      customicons = {}, -- allows alternative set of res images
+      simpletabart = false, -- allows alternative tab rendering
+      tabartsize = 0, -- allows alternative tab size
+      panebgcols = {}, -- allows different background color for panes
+      osxselection = false -- make controls behave more like OS X
+    },
 
     activateoutput = true, -- activate output/console on Run/Debug/Compile
     unhidewindow = false, -- to unhide a gui window


### PR DESCRIPTION
Hello, this change adds a number of config options to change the appearance and the selection behaviour under Mac OS X (for screenshots, see https://github.com/poke1024/ZeroBraneStudio/blob/master/README.md). I personally find ZeroBrane the best IDE for Lua by far but I dislike the Windows-ish appearance of ZeroBrane under OS X, and with these changes it's easy to change it into something quite OS X-ish. If you accept the change, I plan to make available a simple drop-in icon package for OS X that, together with a number of config file options, would make these changes available to other people as well. Cheers, Bernhard Liebl