### PR TITLE
Bugfix: Double clicking on items in the filetree

### DIFF
--- a/src/editor/filetree.lua
+++ b/src/editor/filetree.lua
@@ -387,6 +387,7 @@ local function treeSetConnectorsAndIcons(tree)
     end)
   tree:Connect(wx.wxEVT_COMMAND_TREE_ITEM_ACTIVATED,
     function (event)
+      tree:Toggle(event:GetItem())
       tree:ActivateItem(event:GetItem())
     end)
 


### PR DESCRIPTION
Without this: double clicking items in file tree rebuilt the sub things, but did not open the item itself
With this: Toggles the item correctly on double click