### PR TITLE
ULua integration plugin

### DIFF
--- a/packages/ulua.lua
+++ b/packages/ulua.lua
@@ -1,0 +1,126 @@
+local ulua_root, ulua_lpath, ulua_lcpath, prev_root, prev_lpath, prev_lcpath
+local prev_package_path, prev_package_cpath, prev_require, prev_loaders
+local ffi
+
+local function get_env(name)
+  local has, value = wx.wxGetEnv(name)
+  if has then
+    return value
+  end
+end
+
+local function restore_env(name, value)
+  if not value then
+    wx.wxUnsetEnv(name)
+  else
+    wx.wxSetEnv(name, value)
+  end
+end
+
+prev_root = get_env("LUA_ROOT")
+ulua_root = prev_root or ide.config.path.ulua
+if not ulua_root then
+  error("failed to find ULua, set wither LUA_ROOT or path.ulua in ZeroBrane settings")
+end
+
+ulua_lpath = (";%s/?/init.lua;%s/?.lua"):format(ulua_root, ulua_root)
+
+local win = ide.osname == "Windows"
+local lib_ext = win and "dll" or "so"
+ulua_lcpath = (";%s/?.%s;%s/loadall.%s"):format(ulua_root, lib_ext, ulua_root, lib_ext)
+
+if win then
+  ffi = require "ffi"
+  ffi.cdef[[int SetDllDirectoryA(const char* path);]]
+end
+
+local function set_noconfirm(opt)
+  opt = opt or { }
+  opt.noconfirm = true
+  return opt
+end
+
+local function find_win_runtime(root)
+  local lfs = require "lfs"
+  for path in lfs.dir(root..[[\luajit]]) do
+    if path ~= "." and path ~= ".." then
+      local runtime = root..[[\luajit\]]..path..[[\Windows\]]..jit.arch
+      -- DisplayShell(runtime)
+      return runtime
+    end
+  end
+end
+
+return {
+  name = "ULua plugin",
+  description = "Adds ULua integration to ZeroBrane.",
+  author = "Stefano Peluchetti",
+  version = 1.0,
+
+  onRegister = function(self)
+    wx.wxSetEnv("LUA_ROOT", ulua_root)
+
+    prev_package_path = package.path 
+    package.path = package.path..ulua_lpath
+
+    prev_package_cpath = package.cpath
+    package.cpath = package.cpath..ulua_lcpath
+
+    prev_require = require
+    prev_loaders = { unpack(package.loaders) }
+    local ok, pkg = pcall(require, "host.init.__pkg")
+    if not ok then
+      DisplayShellErr("failed requiring ULua package manager, wrong LUA_ROOT or path.ulua setting? "..tostring(pkg))
+      return
+    end
+
+    if win then
+      local ulua_runtime = find_win_runtime(ulua_root)
+      -- TODO: For some reason vcruntime140.dll cannot be loaded anyway, why?!
+      ffi.C.SetDllDirectoryA(ulua_runtime)
+    end
+
+    -- Force no-confirm for now, user input not supported in local console:
+    local commands = {
+      status = pkg.status,
+      available = pkg.available,
+      add = function(name, version, opt) return pkg.add(name, version, set_noconfirm(opt)) end,
+      remove = function(name, version, opt) return pkg.remove(name, version, set_noconfirm(opt)) end,
+      update = function(opt) return pkg.update(set_noconfirm(opt)) end,
+    }
+
+    -- TODO: On Windows damned console is spawned on commands, improve via wx.
+    ide:AddConsoleAlias("ulua", commands)
+  end,
+
+  onUnRegister = function(self)
+    restore_env("LUA_ROOT", prev_root)
+    package.path = prev_package_path
+    package.cpath = prev_package_cpath
+    require = prev_require
+    for i=1,#package.loaders do
+      package.loaders[i] = nil
+    end
+    for i=1,#prev_loaders do
+      package.loaders[i] = prev_loaders[i]
+    end
+    if win then
+      ffi.C.SetDllDirectoryA("")
+    end
+    ide:RemoveConsoleAlias("ulua")
+  end,
+
+  onInterpreterLoad = function(self, interpreter) 
+    prev_lpath = get_env("LUA_PATH")
+    wx.wxSetEnv("LUA_PATH", (prev_lpath or "")..ulua_lpath) 
+    prev_lcpath = get_env("LUA_CPATH")
+    wx.wxSetEnv("LUA_CPATH", (prev_lcpath or "")..ulua_lcpath)
+    -- TODO: I need the equivalent of './lua -lhost.init.__pkg' in order to 
+    -- TODO: initialize the package manager.
+  end,
+
+  onInterpreterClose = function(self, interpreter)
+    restore_env("LUA_PATH", prev_lpath)
+    restore_env("LUA_CPATH", prev_lcpath)
+  end,
+}

--- a/src/editor/shellbox.lua
+++ b/src/editor/shellbox.lua
@@ -146,7 +146,7 @@ local function getNextHistoryMatch(promptText)
   assert(false, "getNextHistoryMatch coudn't find a proper match")
 end
 
-local function shellPrint(marker, ...)
+local function shellPrint(isPrint, marker, ...) -- TODO: Not correct spacing on OSX.
   local cnt = select('#',...)
   if cnt == 0 then return end -- return if nothing to print
 
@@ -155,7 +155,7 @@ local function shellPrint(marker, ...)
   local text = ''
   for i=1,cnt do
     local x = select(i,...)
-    text = text .. tostring(x)..(i < cnt and "\t" or "")
+    text = text .. tostring(x)..(isPrint and (i < cnt and "\t" or "") or "")
   end
 
   -- split the text into smaller chunks as one large line
@@ -173,7 +173,9 @@ local function shellPrint(marker, ...)
   end
 
   -- add "\n" if it is missing
-  text = text:gsub("\n+$", "") .. "\n"
+  if isPrint then
+    text = text:gsub("\n+$", "") .. "\n"
+  end
 
   local lines = out:GetLineCount()
   local promptLine = isPrompt and getPromptLine() or nil
@@ -196,16 +198,19 @@ local function shellPrint(marker, ...)
 end
 
 DisplayShell = function (...)
-  shellPrint(OUTPUT_MARKER, ...)
+  shellPrint(true, OUTPUT_MARKER, ...)
+end
+DisplayShellWrite = function (...)
+  shellPrint(false, OUTPUT_MARKER, ...)
 end
 DisplayShellErr = function (...)
-  shellPrint(ERROR_MARKER, ...)
+  shellPrint(true, ERROR_MARKER, ...)
 end
 DisplayShellMsg = function (...)
-  shellPrint(MESSAGE_MARKER, ...)
+  shellPrint(true, MESSAGE_MARKER, ...)
 end
 DisplayShellDirect = function (...)
-  shellPrint(nil, ...)
+  shellPrint(true, nil, ...)
 end
 DisplayShellPrompt = function (...)
   -- don't print anything; just mark the line with a prompt mark
@@ -289,6 +294,7 @@ local function createenv ()
       wx.wxEVT_COMMAND_MENU_SELECTED, ID_EXIT))
   end }
   env.os = setmetatable(os, {__index = _G.os})
+  env.io.write = DisplayShellWrite -- TODO: Doing as for os does not work.
   env.print = DisplayShell
   env.dofile = dofile
   env.loadfile = loadfile


### PR DESCRIPTION
To try, download ULua from http://ulua.io, unzip into an arbitrary folder, set either `LUA_ROOT` (precedence) or `path.ulua` in ZeroBrane settings to such folder.

Features introduced:

1. ULua package manager is available from the local console via the `ulua.*` functions which mimic the ones of http://ulua.io/pkg.html: `status, available, add, remove, update`. Because stdin is not supported at the moment we force the `noconfirm` option: operations are executed without warning. ULua modules can be required in the local console (ULua adds two loaders and modifies the `require()` function). Proxy settings can still be set if needed (see official documentation).

2. Interpreters have the correct environment variables set, ULua package manager available via `local pkg = require 'host.init.__pkg'` (should be `local pkg = require 'pkg'` as in plain ULua, but see relevant issue below).

I briefly considered putting ULua inside ZeroBrane itself (the key part is only the pkg module, which requires serpent, lfs, cURL), but having it stand-alone seemed more convenient for me as it makes it easier to upgrade ZeroBrane and ULua separately. Your thoughts on the matter are appreciated.

Issues:

+ the support for `io.write()` on local console doesn't seems correct on OSX: using `ulua.status()` results in a misaligned `|` separator for the versions (it is aligned on Windows and if using ULua directly on OSX)
+ the support for `io.write()` modifies `_G.io.write()` while the same technique employed for `os.exit()` should be used. However, trying to do so resulted in nothing being printed at all in the local console when using `io.write()` (is this modified somewhere else?)
+ I could not find a way to have the loaded interpreter pre-load a library / executes a chunk of code: for ULua's package manager to be set-up correctly I need the equivalent of `lua -lhost.init.__pkg`
+ on Windows, I need to make the Visual Studio 2015 runtime available as ULua C-Lua modules depends on it. The code uses `C.SetDllDirectoryA()` but for obscure reasons it doesn't work: I can `ffi.load()` other libraries in the added directory but not `vcruntime140`. It's not a problem with libraries that depends on other libraries as a different test went fine (OpenBLAS that depends on gfortran dll). Of course setting `PATH` prior to lunching ZeroBrane or putting the required dlls next to ZeroBrane executable solve the issue. I am completely puzzled about this, does it work on your machine?
+ on Windows, the command prompt console is spawned multiple times as I use `os.exec()` in the package manger. I investigated using `wx.wxExecute()` for `os.exec()` in the local console but failed to so: no console was spawned but the commands failed (I could not get a helpful error out of it to guide me to what was wrong)

Your help on the points above would be welcome! 

Thank you.