### PR TITLE
Add. debugger.dir_map settings to manually map remote and local paths

### DIFF
--- a/src/editor/debugger.lua
+++ b/src/editor/debugger.lua
@@ -309,6 +309,15 @@ function debugger:ActivateDocument(file, line, activatehow)
   if not file then return end
   line = tonumber(line)
 
+  local dir_map = ide.config.debugger and ide.config.debugger.dir_map
+  if dir_map then
+    for _, map in ipairs(dir_map) do
+      local n
+      file, n = string.gsub(file, map[1], map[2])
+      if n > 0 then break end
+    end
+  end
+
   -- file can be a filename or serialized file content; deserialize first.
   -- check if the filename starts with '"' and is deserializable
   -- to avoid showing filenames that may look like valid lua code


### PR DESCRIPTION
Settings like
```Lua
debugger.dir_map = {
  {'^/usr/share/(.+)$', '~1/projects/%1'};
}
```


I need this because I need map 2 remote dirs.
`../` maps to may project automatically by ZBS.
But I also has different project on remote side which should map to 
different local path. So full map should looks like:
`../` -> `~/project/client` (done by ZBS)
`/usr/share/server` -> `~/project/server` (done by this new settings)

May be there better name for this optioms