### PR TITLE
Fixed Luacheck not receiving API globals by default or with custom globals.

### DIFF
--- a/src/editor/inspect.lua
+++ b/src/editor/inspect.lua
@@ -37,17 +37,26 @@ if ide.config.staticanalyzer.luacheck then
   end
 
   warnings_from_string = function(src, file)
-    local data = luacheck.check_strings({src}, config.options or {
+    local api_globals = build_env()
+
+    if config.options then
+      -- add user config globals to api table
+      for k, v in pairs(config.options.globals) do
+        api_globals[k] = v
+      end
+      config.options.globals = api_globals
+    end
+
+    local default_options = {
       max_line_length = false,
-      std = {
-        globals = build_env(),
-      },
+      globals = api_globals,
       -- http://luacheck.readthedocs.io/en/stable/warnings.html
       ignore = config.ignore or {
         "11.", -- setting, accessing and mutating globals
         "6..", -- whitespace and style warnings
       },
-    })
+    }
+    local data = luacheck.check_strings({src}, config.options or default_options)
 
     -- I think luacheck can support showing multiple errors
     -- but warnings_from_string is meant to only show one

--- a/src/editor/inspect.lua
+++ b/src/editor/inspect.lua
@@ -25,7 +25,7 @@ if ide.config.staticanalyzer.luacheck then
   local function build_env()
     local globals = {}
 
-    for _, api in pairs(ide:GetInterpreter():GetAPI()) do
+    for _, api in pairs(ide:GetInterpreter():GetAPI() or {}) do
       -- not sure if this is how you're supposed to get an api
       local ok, tbl = pcall(require, "api/lua/" .. api)
       if ok then

--- a/src/editor/inspect.lua
+++ b/src/editor/inspect.lua
@@ -41,7 +41,7 @@ if ide.config.staticanalyzer.luacheck then
 
     if config.options then
       -- add user config globals to api table
-      for k, v in pairs(config.options.globals) do
+      for k, v in pairs(config.options.globals or {}) do
         api_globals[k] = v
       end
       config.options.globals = api_globals


### PR DESCRIPTION
This fixes passing API globals to Luacheck and allows users to add new globals via config files.