### PR TITLE
Fix live scheme update

### DIFF
--- a/src/editor/style.lua
+++ b/src/editor/style.lua
@@ -414,7 +414,7 @@ function ReApplySpecAndStyles()
 
   for _, doc in pairs(ide:GetDocuments()) do
     local editor = doc:GetEditor()
-    if editor.spec then editor:SetupKeywords(nil, editor.spec) end
+    if editor.spec then StylesApplyToEditor(ide.config.styles, editor, nil, nil, editor.spec.lexerstyleconvert) end
   end
 end
 


### PR DESCRIPTION
Scheme picker doesn’t work for me; this PR fixes it.
Note that `editor:SetupKeywords(nil, editor.spec)` is always no-op as it checks for `spec == editor.spec`.