### PR TITLE
Update Fennel keywords in lexer.

### DIFF
--- a/lualibs/lexers/fennel.lua
+++ b/lualibs/lexers/fennel.lua
@@ -13,11 +13,17 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:modify_rule('keyword', token(lexer.KEYWORD, word_match[[
-  % * + - ->> -> -?>> -?> .. . // / : <= < = >= > ^ ~= λ
-  and comment do doc doto each eval-compiler fn for global hashfn if include
-  lambda length let local lua macro macros match not not= or partial quote
-  require-macros set set-forcibly! tset values var when while
+  # % * + - -> ->> -?> -?>> . .. / // : < <= = > >= ?. ^ accumulate
+  and band bnot bor bxor collect comment do doto each eval-compiler fn
+  for global hashfn icollect if import-macros include lambda length
+  let local lshift lua macro macrodebug macros match not not=
+  or partial pick-args pick-values quote require-macros rshift set
+  set-forcibly! tset values var when while with-open ~= λ
 ]]))
+
+-- To regenerate the above:
+-- (table.concat (doto (icollect [k v (pairs (fennel.syntax))]
+--                     (if (or v.special? v.macro?) k)) table.sort) " ")
 
 -- Identifiers.
 local initial = lexer.alpha + S"|$%&#*+-./:<=>?~^_λ!"
@@ -26,6 +32,7 @@ lex:modify_rule('identifier', token(lexer.IDENTIFIER, initial * subsequent^0))
 
 -- Strings.
 lex:modify_rule('string', token(lexer.STRING, lexer.range('"')))
+lex:add_rule('kwstring', token(lexer.STRING, P(":") * subsequent^1))
 
 -- Comments.
 lex:modify_rule('comment', token(lexer.COMMENT, lexer.to_eol(';')))
@@ -33,5 +40,6 @@ lex:modify_rule('comment', token(lexer.COMMENT, lexer.to_eol(';')))
 -- Ignore these rules.
 lex:modify_rule('label', P(false))
 lex:modify_rule('operator', P(false))
+lex:modify_rule('longstring', P(false))
 
 return lex

--- a/lualibs/lexers/fennel.lua
+++ b/lualibs/lexers/fennel.lua
@@ -26,7 +26,7 @@ lex:modify_rule('keyword', token(lexer.KEYWORD, word_match[[
 --                     (if (or v.special? v.macro?) k)) table.sort) " ")
 
 -- Identifiers.
-local initial = lexer.alpha + S"|$%&#*+-./:<=>?~^_λ!"
+local initial = lexer.alpha + S"|$%&#*+-/<=>?^_λ!"
 local subsequent = initial + lexer.digit
 lex:modify_rule('identifier', token(lexer.IDENTIFIER, initial * subsequent^0))
 


### PR DESCRIPTION
Also remove the inherited "longstring" rule from the Lua lexer.

I tried adding a "kwstring" rule for `:this-style` string but it seems to have no effect; any idea what I'm doing wrong here?

    lex:add_rule('kwstring', token(lexer.STRING, P(":") * subsequent^1))

thanks!